### PR TITLE
Add old cipher for older versions of ROS

### DIFF
--- a/sshutils/dial.go
+++ b/sshutils/dial.go
@@ -72,6 +72,7 @@ func Dial(ctx context.Context, address string, c *Config) (client *Client, err e
 		Auth:            auth,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
+	config.Config.Ciphers = append(config.Config.Ciphers, "aes128-cbc")
 
 	var (
 		sshConn ssh.Conn


### PR DESCRIPTION
Fix a problem with SSH connections to older versions of ROS (tested on 6.5)