### PR TITLE
Remove deprecated use of `-once` argument in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ FROM alpine
 WORKDIR /app
 COPY --from=build-env /go/src/github.com/ecadlabs/rosdump/rosdump /usr/bin/rosdump
 ENTRYPOINT ["/usr/bin/rosdump"]
-CMD ["-c", "/etc/rosdump.yml", "-once"]
+CMD ["-c", "/etc/rosdump.yml"]


### PR DESCRIPTION
This seems to break the Docker image. Would be nice to see source code overhaul in general as well, it's been a while :)